### PR TITLE
Fix Python 3.9 incompatibility with DINOv2 union types

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -39,15 +39,15 @@ dependencies:
   - libzlib=1.2.13=h4ab18f5_6
   - ncurses=6.5=h59595ed_0
   - nettle=3.6=he412f7d_0
-  - numpy=1.26.4=py39h474f0d3_0
+  - numpy=1.26.4
   - openh264=2.1.1=h780b84a_0
   - openjpeg=2.5.2=h488ebb8_0
   - openssl=3.3.0=h4ab18f5_3
-  - pillow=10.3.0=py39h90c7501_0
+  - pillow=10.3.0
   - pip=24.0=pyhd8ed1ab_0
   - pthread-stubs=0.4=h36c2ea0_1001
-  - python=3.9.19=h0755675_0_cpython
-  - python_abi=3.9=4_cp39
+  - python=3.10
+  - python_abi=3.10
   - readline=8.2=h8228510_1
   - setuptools=70.0.0=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101


### PR DESCRIPTION
## Summary
Upgrades Python from 3.9 to 3.10 in `environment.yaml` to fix #25.

DINOv2's latest code (loaded via `torch.hub`) uses PEP 604 union type syntax (`float | None`) in `dinov2/layers/attention.py:58`, which requires Python 3.10+. The simplest fix is upgrading the conda environment.

## Changes
- `python=3.9.19` → `python=3.10`
- `python_abi=3.9` → `python_abi=3.10`
- Removed Python 3.9-specific conda build hashes from `numpy` and `pillow` pins

## The error (from Issue #25)
```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

## Test plan
- [ ] Recreate conda env with updated `environment.yaml`
- [ ] Verify `torch.hub.load("facebookresearch/dinov2", "dinov2_vits14")` loads without TypeError
- [ ] Run planning: `python plan.py model_name=point_maze n_evals=5 planner=cem goal_H=5 goal_source=random_state planner.opt_steps=30`