### PR TITLE
fix: resolve NCCL deadlock and Python 3.9 compatibility

### DIFF
--- a/models/dino.py
+++ b/models/dino.py
@@ -1,13 +1,38 @@
+import os
+import subprocess
 import torch
 import torch.nn as nn
+from typing import Optional
 
 torch.hub._validate_not_a_forked_repo=lambda a,b,c: True
+
+def _patch_dinov2_py39(cache_dir):
+    """Patch DINOv2 source to replace PEP 604 union syntax (float | None)
+    with typing.Optional for Python 3.9 compatibility."""
+    import glob
+    for py_file in glob.glob(os.path.join(cache_dir, "dinov2", "**", "*.py"), recursive=True):
+        with open(py_file, "r") as f:
+            content = f.read()
+        if "float | None" in content:
+            content = content.replace("float | None", "Optional[float]")
+            if "from typing import Optional" not in content:
+                content = "from typing import Optional\n" + content
+            with open(py_file, "w") as f:
+                f.write(content)
 
 class DinoV2Encoder(nn.Module):
     def __init__(self, name, feature_key):
         super().__init__()
         self.name = name
-        self.base_model = torch.hub.load("facebookresearch/dinov2", name)
+        cache_dir = os.path.join(torch.hub.get_dir(), "facebookresearch_dinov2_main")
+        if not os.path.exists(os.path.join(cache_dir, "dinov2", "hub", "backbones.py")):
+            os.makedirs(torch.hub.get_dir(), exist_ok=True)
+            subprocess.run(
+                ["git", "clone", "https://github.com/facebookresearch/dinov2.git", cache_dir],
+                check=True,
+            )
+        _patch_dinov2_py39(cache_dir)
+        self.base_model = torch.hub.load(cache_dir, name, source="local", trust_repo=True)
         self.feature_key = feature_key
         self.emb_dim = self.base_model.num_features
         if feature_key == "x_norm_patchtokens":

--- a/train.py
+++ b/train.py
@@ -289,9 +289,15 @@ class Trainer:
             if not self.train_decoder:
                 for param in self.decoder.parameters():
                     param.requires_grad = False
-        self.encoder, self.predictor, self.decoder = self.accelerator.prepare(
-            self.encoder, self.predictor, self.decoder
-        )
+        if self.train_encoder:
+            self.encoder, self.predictor, self.decoder = self.accelerator.prepare(
+                self.encoder, self.predictor, self.decoder
+            )
+        else:
+            self.predictor, self.decoder = self.accelerator.prepare(
+                self.predictor, self.decoder
+            )
+            self.encoder = self.encoder.to(self.accelerator.device)
         self.model = hydra.utils.instantiate(
             self.cfg.model,
             encoder=self.encoder,
@@ -794,8 +800,6 @@ class Trainer:
 
         if self.accelerator.is_main_process:
             os.makedirs(phase, exist_ok=True)
-        self.accelerator.wait_for_everyone()
-
         self.plot_imgs(
             imgs,
             num_columns=num_samples * num_frames,


### PR DESCRIPTION
## Problem

Multi-GPU training with DDP hangs after the first iteration due to NCCL deadlock.

## Root Causes (3 bugs)

### 1. `plot_samples()` calls `wait_for_everyone()` only on rank 0
`plot_samples()` is gated by `is_main_process`, but internally calls `self.accelerator.wait_for_everyone()` - a collective NCCL operation that requires ALL ranks. Since only rank 0 executes it, rank 0 waits forever.

**Fix:** Remove the `wait_for_everyone()` call.

### 2. Frozen encoder wrapped in DDP causes bucket deadlock
When `train_encoder=False`, the encoder has no gradients but is still wrapped in `accelerator.prepare()` (DDP). DDP expects gradient sync but the frozen encoder never produces gradients, causing NCCL bucket deadlock.

**Fix:** Only wrap encoder in DDP when `train_encoder=True`.

### 3. DINOv2 Python 3.9 incompatibility
DINOv2 uses PEP 604 union syntax requiring Python 3.10+.

**Fix:** Clone DINOv2 locally and patch type annotations.

## Testing

Verified on 7-GPU setup (H20). Training runs stably at 2000+ iterations, all GPUs at 100% utilization.